### PR TITLE
Fix penalty_milliseconds typo

### DIFF
--- a/modules/Experimentation/Experimentation.ts
+++ b/modules/Experimentation/Experimentation.ts
@@ -158,13 +158,13 @@ export class Reaction_Time_Measurement extends Measurement_Type {
 
 export class Reaction_Time_Penalty_Measurement extends Measurement_Type {
 
-    penalty_miliseconds: number;
+    penalty_milliseconds: number;
     penalty_started:boolean = false;
     penalty_start_point = null;
 
     constructor(input_type: Experiment_Input_Type, penalty_seconds: number) {
         super(input_type);
-        this.penalty_miliseconds = penalty_seconds * 1000;
+        this.penalty_milliseconds = penalty_seconds * 1000;
     }
 
     demands_penalty():boolean {
@@ -186,7 +186,7 @@ export class Reaction_Time_Penalty_Measurement extends Measurement_Type {
 
     penalty_is_over() {
         let diff = (new Date().getTime().valueOf())-this.start_time;
-        return !this.penalty_started || diff >= this.penalty_miliseconds;
+        return !this.penalty_started || diff >= this.penalty_milliseconds;
     }
 
     start_measurement(task: Task) {
@@ -206,13 +206,13 @@ export class Time_To_Finish_Measurement extends Measurement_Type {
 
 export class Time_To_Finish_With_Time_Penalty_Measurement extends Time_To_Finish_Measurement {
 
-    penalty_miliseconds: number;
+    penalty_milliseconds: number;
     penalty_started:boolean = false;
     penalty_start_point = null;
 
     constructor(input_type: Experiment_Input_Type, penalty_seconds: number) {
         super(input_type);
-        this.penalty_miliseconds = penalty_seconds * 1000;
+        this.penalty_milliseconds = penalty_seconds * 1000;
     }
 
     demands_penalty():boolean {
@@ -234,7 +234,7 @@ export class Time_To_Finish_With_Time_Penalty_Measurement extends Time_To_Finish
 
     penalty_is_over() {
         let diff = (new Date().getTime().valueOf())-this.start_time;
-        return !this.penalty_started || diff >= this.penalty_miliseconds;
+        return !this.penalty_started || diff >= this.penalty_milliseconds;
     }
 
     start_measurement(task: Task) {


### PR DESCRIPTION
## Summary
- fix misspelled `penalty_milliseconds` property in Experimentation classes

## Testing
- `npx tsc modules/Experimentation/Experimentation.ts --target es2017 --lib es2017,dom --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6847f33ce7d883319099a4a910b4e85f